### PR TITLE
Add dist folder to set destination folder

### DIFF
--- a/README.md
+++ b/README.md
@@ -30,6 +30,24 @@ $config = [
 ];
 ```
 
+If you would like to configure the destination folder of the compiled css, then configure the converter in `web.php` in the following way:
+
+```php
+$config = [
+    ...
+    'components' => [
+        'assetManager' => [
+            'converter' => [
+                'class' => 'lucidtaz\yii2scssphp\ScssAssetConverter',
+                'distFolder => 'css',
+            ],
+        ],
+        ...
+    ],
+    ...
+];
+```
+
 If the `AppAsset` is placed in `/assets` and the scss file in
 `/assets/source/site.scss`, your `AppAsset.php` could look like:
 

--- a/src/ScssAssetConverter.php
+++ b/src/ScssAssetConverter.php
@@ -71,10 +71,10 @@ class ScssAssetConverter extends Component implements AssetConverterInterface
         if ($extension !== 'scss') {
             return $asset;
         }
-        $cssAsset = $this->replaceExtension($asset, 'css');
+        $cssAsset = $this->getCssAsset($asset, 'css');
 
         $inFile = "$basePath/$asset";
-        $outFile = $this->distFolder ? "$basePath/$this->distFolder/$cssAsset" : "$basePath/$cssAsset";
+        $outFile = "$basePath/$cssAsset";
         
         $this->compiler->setImportPaths(dirname($inFile));
 
@@ -85,7 +85,7 @@ class ScssAssetConverter extends Component implements AssetConverterInterface
 
         $this->convertAndSaveIfNeeded($inFile, $outFile);
 
-        return $this->distFolder ? $this->distFolder . '/' . $cssAsset : $cssAsset;
+        return $cssAsset;
     }
 
     private function getExtension(string $filename): string
@@ -93,12 +93,17 @@ class ScssAssetConverter extends Component implements AssetConverterInterface
         return pathinfo($filename, PATHINFO_EXTENSION);
     }
 
-    private function replaceExtension(string $filename, string $newExtension): string
+    private function getCssAsset(string $filename, string $newExtension): string
     {
-        $extensionlessFilename = pathinfo($filename, PATHINFO_FILENAME);
-        return "$extensionlessFilename.$newExtension";
+        $newFileName = pathinfo($filename, PATHINFO_FILENAME) . '.' . $newExtension;
+        return $this->distFolder ? $this->distFolder . '/' . $newFileName : $newFileName;
     }
 
+    /**
+     * @param string $inFile
+     * @param string $outFile
+     * @throws \yii\base\Exception
+     */
     private function convertAndSaveIfNeeded(string $inFile, string $outFile)
     {
         if ($this->shouldConvert($inFile, $outFile)) {

--- a/src/ScssAssetConverter.php
+++ b/src/ScssAssetConverter.php
@@ -8,6 +8,7 @@ use lucidtaz\yii2scssphp\storage\Storage;
 use RuntimeException;
 use Yii;
 use yii\base\Component;
+use yii\helpers\FileHelper;
 use yii\web\AssetConverterInterface;
 
 class ScssAssetConverter extends Component implements AssetConverterInterface
@@ -65,6 +66,7 @@ class ScssAssetConverter extends Component implements AssetConverterInterface
      * @param string $asset the asset file path, relative to $basePath
      * @param string $basePath the directory the $asset is relative to.
      * @return string the converted asset file path, relative to $basePath.
+     * @throws \yii\base\Exception
      */
     public function convert($asset, $basePath)
     {
@@ -84,6 +86,7 @@ class ScssAssetConverter extends Component implements AssetConverterInterface
             return $asset;
         }
 
+        $this->createDistFolderIfNotExists($outFile);
         $this->convertAndSaveIfNeeded($inFile, $outFile);
 
         return $this->distFolder ? $this->distFolder . '/' . $cssAsset : $cssAsset;
@@ -127,5 +130,17 @@ class ScssAssetConverter extends Component implements AssetConverterInterface
     private function isOlder(string $fileA, string $fileB): bool
     {
         return $this->storage->getMtime($fileA) < $this->storage->getMtime($fileB);
+    }
+
+    /**
+     * @param $outFile
+     * @throws \yii\base\Exception
+     */
+    private function createDistFolderIfNotExists($outFile)
+    {
+        $dir = dirname($outFile);
+        if (!is_dir($dir)) {
+            FileHelper::createDirectory($dir);
+        }
     }
 }

--- a/src/ScssAssetConverter.php
+++ b/src/ScssAssetConverter.php
@@ -28,6 +28,23 @@ class ScssAssetConverter extends Component implements AssetConverterInterface
 
     private $compiler;
 
+    /**
+     * Set the destination folder where to copy the compiled css file.
+     * If the value is null, then it will be generated into the sourcePath of the asset bundle.
+     *
+     * ```
+     * 'assetManager' => [
+     *     'converter' => [
+     *         'class' => \lucidtaz\yii2scssphp\ScssAssetConverter::class,
+     *         'distFolder' => 'css',
+     *     ],
+     * ],
+     * ```
+     *
+     * @var string|null
+     */
+    public $distFolder;
+
     public function init()
     {
         parent::init();
@@ -52,7 +69,7 @@ class ScssAssetConverter extends Component implements AssetConverterInterface
         $cssAsset = $this->replaceExtension($asset, 'css');
 
         $inFile = "$basePath/$asset";
-        $outFile = "$basePath/$cssAsset";
+        $outFile = $this->distFolder ? "$basePath/$this->distFolder/$cssAsset" : "$basePath/$cssAsset";
         
         $this->compiler->setImportPaths(dirname($inFile));
 
@@ -63,7 +80,7 @@ class ScssAssetConverter extends Component implements AssetConverterInterface
 
         $this->convertAndSaveIfNeeded($inFile, $outFile);
 
-        return $cssAsset;
+        return $this->distFolder ? $this->distFolder . '/' . $cssAsset : $cssAsset;
     }
 
     private function getExtension(string $filename): string

--- a/src/ScssAssetConverter.php
+++ b/src/ScssAssetConverter.php
@@ -27,9 +27,6 @@ class ScssAssetConverter extends Component implements AssetConverterInterface
      */
     public $forceConvert = false;
 
-    /**
-     * @var Compiler
-     */
     private $compiler;
 
     /**
@@ -133,7 +130,7 @@ class ScssAssetConverter extends Component implements AssetConverterInterface
     }
 
     /**
-     * @param $outFile
+     * @param string $outFile
      * @throws \yii\base\Exception
      */
     private function createDistFolderIfNotExists($outFile)

--- a/src/ScssAssetConverter.php
+++ b/src/ScssAssetConverter.php
@@ -83,7 +83,6 @@ class ScssAssetConverter extends Component implements AssetConverterInterface
             return $asset;
         }
 
-        $this->createDistFolderIfNotExists($outFile);
         $this->convertAndSaveIfNeeded($inFile, $outFile);
 
         return $this->distFolder ? $this->distFolder . '/' . $cssAsset : $cssAsset;
@@ -104,6 +103,7 @@ class ScssAssetConverter extends Component implements AssetConverterInterface
     {
         if ($this->shouldConvert($inFile, $outFile)) {
             $css = $this->compiler->compile($this->storage->get($inFile), $inFile);
+            $this->createDistFolderIfNotExists($outFile);
             $this->storage->put($outFile, $css);
         }
     }

--- a/src/ScssAssetConverter.php
+++ b/src/ScssAssetConverter.php
@@ -26,6 +26,9 @@ class ScssAssetConverter extends Component implements AssetConverterInterface
      */
     public $forceConvert = false;
 
+    /**
+     * @var Compiler
+     */
     private $compiler;
 
     /**
@@ -45,6 +48,9 @@ class ScssAssetConverter extends Component implements AssetConverterInterface
      */
     public $distFolder;
 
+    /**
+     * @throws \yii\base\InvalidConfigException
+     */
     public function init()
     {
         parent::init();


### PR DESCRIPTION
My file structure of an asset bundle are the following:

```
- assets
  - main
    - css
      - img
        footer.img
      style.css
    - scss
      _mixins.scss
      style.scss
  MainAsset.php
```
So the current class will generate the css file in `assets/main/style.css`. This way hard to set the img assets in scss to be compatible with the compiled css file.

With `$distFolder` I can set it to `css` so the compiler will generate the css file into `assets/main/css/style.css`, then i do not have extra path settings in scss files :)

Sadly if you want to use this folder structure, you have to update in every assetbundle, since the `convert` method receives only asset file and basePath.

But it does not breaks BC :)