### PR TITLE
Upgrade PHP minimum version to 7.1

### DIFF
--- a/.scrutinizer.yml
+++ b/.scrutinizer.yml
@@ -1,7 +1,7 @@
 build:
     environment:
         php:
-            version: 7.1.*
+            version: 7.2
     tests:
         override:
             -

--- a/.scrutinizer.yml
+++ b/.scrutinizer.yml
@@ -1,7 +1,7 @@
 build:
     environment:
         php:
-            version: 7.0.*
+            version: 7.1.*
     tests:
         override:
             -

--- a/.travis.yml
+++ b/.travis.yml
@@ -1,8 +1,8 @@
 language: php
 php:
-  - '7.0'
   - '7.1'
   - '7.2'
+  - '7.3'
 
 env:
   matrix:

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -9,6 +9,7 @@ and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0
 - Ability to customize the underlying SCSS Compiler via the `$compiler` attribute
 
 ### Removed
+- Support for PHP 7.0, following PHP's own support schedule
 - `$formatter` customization attribute
 
 ## [0.2.1] - 2018-04-22

--- a/composer.json
+++ b/composer.json
@@ -6,15 +6,15 @@
         "MIT"
     ],
     "require": {
-        "php": ">=7.0.0",
+        "php": ">=7.1.0",
         "yiisoft/yii2": "^2.0.13",
         "leafo/scssphp": "^0.7.5",
         "guzzlehttp/guzzle": "^6.3"
     },
     "require-dev": {
-        "phpunit/phpunit": "^6.2",
-        "phpstan/phpstan": "~0.9.0",
-        "phpstan/phpstan-phpunit": "~0.9.0"
+        "phpunit/phpunit": "^7.5",
+        "phpstan/phpstan": "^0.11.2",
+        "phpstan/phpstan-phpunit": "^0.11.0"
     },
     "autoload": {
         "psr-4": { "lucidtaz\\yii2scssphp\\": "src/" }

--- a/docker/integration/Dockerfile
+++ b/docker/integration/Dockerfile
@@ -1,9 +1,13 @@
-FROM ubuntu:16.04
+FROM ubuntu:18.04
 
 WORKDIR /project/integration-source
 
+# Workaround for tzdata asking for input
+# https://askubuntu.com/questions/909277/avoiding-user-interaction-with-tzdata-when-installing-certbot-in-a-docker-contai
+ENV DEBIAN_FRONTEND=noninteractive
+
 # Prepare PHP installation
-RUN apt-get update && apt-get install --yes composer unzip php7.0-cli php7.0-mbstring php7.0-dom php7.0-curl
+RUN apt-get update && apt-get install --yes composer unzip php7.2-cli php7.2-mbstring php7.2-dom php7.2-curl
 
 # Install basic Yii application from upstream
 RUN composer create-project --no-interaction --prefer-dist yiisoft/yii2-app-basic .

--- a/phpstan.neon
+++ b/phpstan.neon
@@ -1,10 +1,2 @@
 includes:
   - vendor/phpstan/phpstan-phpunit/extension.neon
-parameters:
-  ignoreErrors:
-    # phpstan-phpunit 0.9 doesn't cope yet with knowing the type after an
-    # ->assertInstanceOf() call. Version 0.10 does, so these ignores can go away
-    # again. After upgrading. However, that needs PHPUnit >=7, which required
-    # PHP >= 7.1. So it depends on when we want to drop support for PHP 7.0
-    - '#Access to an undefined property object::\$forceConvert.#'
-    - '#Access to an undefined property object::\$compiler.#'

--- a/src/ScssAssetConverter.php
+++ b/src/ScssAssetConverter.php
@@ -93,7 +93,7 @@ class ScssAssetConverter extends Component implements AssetConverterInterface
         return "$relativePath$extensionlessFilename.$newExtension";
     }
 
-    private function convertAndSaveIfNeeded(string $inFile, string $outFile)
+    private function convertAndSaveIfNeeded(string $inFile, string $outFile): void
     {
         if ($this->shouldConvert($inFile, $outFile)) {
             $css = $this->compiler->compile($this->storage->get($inFile), $inFile);

--- a/tests/integration/IntegrationTest.php
+++ b/tests/integration/IntegrationTest.php
@@ -10,7 +10,7 @@ class IntegrationTest extends TestCase
     /** @var Client */
     private $client;
 
-    protected function setUp()
+    protected function setUp(): void
     {
         parent::setUp();
         $this->client = new Client([
@@ -52,7 +52,7 @@ class IntegrationTest extends TestCase
     /**
      * @depends testThatAssetConversionWorks
      */
-    public function testThatItUsesCustomizedConfiguration(string $css)
+    public function testThatItUsesCustomizedConfiguration(string $css): void
     {
         // Verify that the customization done in config/web.php works.
         // Integration test is set up with crunched formatter

--- a/tests/unit/CorruptStorageDecorator.php
+++ b/tests/unit/CorruptStorageDecorator.php
@@ -44,7 +44,7 @@ class CorruptStorageDecorator implements Storage
         $this->storage = $storage;
     }
 
-    private function doThrow()
+    private function doThrow(): void
     {
         throw new RuntimeException('Intentional exception to simulate corruption');
     }

--- a/tests/unit/DependencyInjectionTest.php
+++ b/tests/unit/DependencyInjectionTest.php
@@ -10,13 +10,13 @@ use Yii;
 
 class DependencyInjectionTest extends TestCase
 {
-    public function testThatItInstantiatesFromClassName()
+    public function testThatItInstantiatesFromClassName(): void
     {
         $assetConverter = Yii::createObject(ScssAssetConverter::class);
         $this->assertInstanceOf(ScssAssetConverter::class, $assetConverter);
     }
 
-    public function testThatItInstantiatesFromConfigArray()
+    public function testThatItInstantiatesFromConfigArray(): void
     {
         $assetConverter = Yii::createObject([
             'class' => ScssAssetConverter::class,
@@ -24,7 +24,7 @@ class DependencyInjectionTest extends TestCase
         $this->assertInstanceOf(ScssAssetConverter::class, $assetConverter);
     }
 
-    public function testThatScalarAttributeCanBeCustomized()
+    public function testThatScalarAttributeCanBeCustomized(): void
     {
         $control = new ScssAssetConverter();
         $this->assertFalse($control->forceConvert, 'Test precondition');
@@ -39,7 +39,7 @@ class DependencyInjectionTest extends TestCase
         $this->assertTrue($assetConverter->forceConvert, 'Attribute must be taken from DI parameters');
     }
 
-    public function testThatCompilerCanBeCustomizedDirectly()
+    public function testThatCompilerCanBeCustomizedDirectly(): void
     {
         $input = "#blop { color: black; display: block; }";
         $expectedDefaultOutput = "#blop {\n  color: black;\n  display: block; }\n";
@@ -63,7 +63,7 @@ class DependencyInjectionTest extends TestCase
         $this->assertEquals($expectedCustomizedOutput, $compiled, 'DI formatter customization has effect on compiled output');
     }
 
-    public function testThatCompilerCanBeCustomizedInContainer()
+    public function testThatCompilerCanBeCustomizedInContainer(): void
     {
         $input = "#blop { color: black; display: block; }";
         $expectedDefaultOutput = "#blop {\n  color: black;\n  display: block; }\n";
@@ -89,7 +89,7 @@ class DependencyInjectionTest extends TestCase
         Yii::$container->clear(Compiler::class);
     }
 
-    public function testThatOverriddenCompilerCanBeBoundInContainer()
+    public function testThatOverriddenCompilerCanBeBoundInContainer(): void
     {
         $input = "#blop { color: black; display: block; }";
         $expectedDefaultOutput = "#blop {\n  color: black;\n  display: block; }\n";

--- a/tests/unit/FsStorageTest.php
+++ b/tests/unit/FsStorageTest.php
@@ -10,12 +10,12 @@ class FsStorageTest extends TestCase
 {
     private $scratchFilename;
 
-    public function setUp()
+    public function setUp(): void
     {
         $this->scratchFilename = tempnam(sys_get_temp_dir(), 'lucidtaz_');
     }
 
-    public function tearDown()
+    public function tearDown(): void
     {
         if (file_exists($this->scratchFilename)) {
             unlink($this->scratchFilename);
@@ -23,7 +23,7 @@ class FsStorageTest extends TestCase
         $this->scratchFilename = null;
     }
 
-    public function testExists()
+    public function testExists(): void
     {
         $storage = new FsStorage;
 
@@ -31,7 +31,7 @@ class FsStorageTest extends TestCase
         $this->assertFalse($storage->exists(sys_get_temp_dir() . '/lucidtaz_non_existing'));
     }
 
-    public function testGet()
+    public function testGet(): void
     {
         $storage = new FsStorage;
 
@@ -39,7 +39,7 @@ class FsStorageTest extends TestCase
         $this->assertEquals('contents', $storage->get($this->scratchFilename));
     }
 
-    public function testPut()
+    public function testPut(): void
     {
         $storage = new FsStorage;
 
@@ -51,7 +51,7 @@ class FsStorageTest extends TestCase
         $this->assertEquals('contents', $contents);
     }
 
-    public function testRemove()
+    public function testRemove(): void
     {
         $storage = new FsStorage;
 
@@ -67,7 +67,7 @@ class FsStorageTest extends TestCase
         $this->assertFalse($secondCallSuccess);
     }
 
-    public function testTouch()
+    public function testTouch(): void
     {
         $storage = new FsStorage;
 
@@ -78,7 +78,7 @@ class FsStorageTest extends TestCase
         $this->assertEquals($mtime, filemtime($this->scratchFilename));
     }
 
-    public function testGetMtime()
+    public function testGetMtime(): void
     {
         $storage = new FsStorage;
 
@@ -91,7 +91,7 @@ class FsStorageTest extends TestCase
         $this->assertEquals($mtime, $actual);
     }
 
-    public function testGetMtimeException()
+    public function testGetMtimeException(): void
     {
         $storage = new FsStorage;
 

--- a/tests/unit/ScssAssetConverterTest.php
+++ b/tests/unit/ScssAssetConverterTest.php
@@ -2,7 +2,6 @@
 
 namespace lucidtaz\yii2scssphp\tests\unit;
 
-use Leafo\ScssPhp\Compiler;
 use lucidtaz\yii2scssphp\ScssAssetConverter;
 use lucidtaz\yii2scssphp\storage\FsStorage;
 use lucidtaz\yii2scssphp\storage\Storage;
@@ -37,7 +36,7 @@ class ScssAssetConverterTest extends TestCase
      */
     private $storage;
 
-    public function setUp()
+    public function setUp(): void
     {
         $this->storage = new MemoryStorage;
 
@@ -47,32 +46,32 @@ class ScssAssetConverterTest extends TestCase
         $this->storage->put('base/path/already_converted.css', "#blop { color: black; }");
     }
 
-    public function tearDown()
+    public function tearDown(): void
     {
         unset($this->storage);
     }
 
-    public function testInitUsesFilesystem()
+    public function testInitUsesFilesystem(): void
     {
         $assetConverter = new ScssAssetConverter;
         $this->assertInstanceOf(FsStorage::class, $assetConverter->storage);
     }
 
-    public function testConvertGivesResult()
+    public function testConvertGivesResult(): void
     {
         $assetConverter = new ScssAssetConverter(['storage' => $this->storage]);
         $result = $assetConverter->convert('asset', 'base/path');
         $this->assertNotEmpty($result);
     }
 
-    public function testConvertLeavesCssAlone()
+    public function testConvertLeavesCssAlone(): void
     {
         $assetConverter = new ScssAssetConverter(['storage' => $this->storage]);
         $result = $assetConverter->convert('other.css', 'base/path');
         $this->assertEquals('other.css', $result);
     }
 
-    public function testConvertKeepsRelativePathIntact()
+    public function testConvertKeepsRelativePathIntact(): void
     {
         $assetConverter = new ScssAssetConverter(['storage' => $this->storage]);
         $result = $assetConverter->convert('path/asset.scss', 'base');
@@ -80,21 +79,21 @@ class ScssAssetConverterTest extends TestCase
         $this->assertTrue($this->storage->exists('base/path/asset.css'));
     }
 
-    public function testConvertLeavesNonExistingFileAlone()
+    public function testConvertLeavesNonExistingFileAlone(): void
     {
         $assetConverter = new ScssAssetConverter(['storage' => $this->storage]);
         $result = $assetConverter->convert('nonexisting.scss', 'base/path');
         $this->assertEquals('nonexisting.scss', $result);
     }
 
-    public function testConvertHandlesScss()
+    public function testConvertHandlesScss(): void
     {
         $assetConverter = new ScssAssetConverter(['storage' => $this->storage]);
         $result = $assetConverter->convert('asset.scss', 'base/path');
         $this->assertEquals('asset.css', $result);
     }
 
-    public function testConvertActuallyWorks()
+    public function testConvertActuallyWorks(): void
     {
         $assetConverter = new ScssAssetConverter(['storage' => $this->storage]);
         $assetConverter->convert('asset.scss', 'base/path');
@@ -102,7 +101,7 @@ class ScssAssetConverterTest extends TestCase
         $this->assertEquals("#blop {\n  color: black; }\n", $generatedCss);
     }
 
-    public function testConvertHandlesImport()
+    public function testConvertHandlesImport(): void
     {
         // Unfortunately we cannot currently test this using the mocked
         // filesystem, since leafo/scss directly accesses the filesystem. If we
@@ -130,7 +129,7 @@ class ScssAssetConverterTest extends TestCase
         $storage->remove($targetFile);
     }
 
-    public function testConvertSkipsUpToDateResults()
+    public function testConvertSkipsUpToDateResults(): void
     {
         $this->storage->touch('base/path/already_converted.scss', 5);
         $this->storage->touch('base/path/already_converted.css', 6); // Newer
@@ -143,7 +142,7 @@ class ScssAssetConverterTest extends TestCase
         $this->assertEquals(6, $currentModificationTime, 'File modification time should not change');
     }
 
-    public function testConvertRespectsForceConvert()
+    public function testConvertRespectsForceConvert(): void
     {
         $this->storage->touch('base/path/already_converted.scss', 5);
         $this->storage->touch('base/path/already_converted.css', 6); // Newer
@@ -156,7 +155,7 @@ class ScssAssetConverterTest extends TestCase
         $this->assertGreaterThan(6, $currentModificationTime, 'The modification time has increased');
     }
 
-    public function testConvertWorksOnOutdatedResults()
+    public function testConvertWorksOnOutdatedResults(): void
     {
         $this->storage->touch('base/path/already_converted.scss', 5);
         $this->storage->touch('base/path/already_converted.css', 4); // Older
@@ -169,7 +168,7 @@ class ScssAssetConverterTest extends TestCase
         $this->assertGreaterThan(4, $currentModificationTime, 'The modification time has increased');
     }
 
-    public function testConvertWorksOnUnknownAgeResults()
+    public function testConvertWorksOnUnknownAgeResults(): void
     {
         $this->storage->touch('base/path/already_converted.scss', 5);
         $this->storage->touch('base/path/already_converted.css', 4); // Older
@@ -185,7 +184,7 @@ class ScssAssetConverterTest extends TestCase
         $this->assertGreaterThan(4, $currentModificationTime, 'The modification time has increased');
     }
 
-    public function testGetCssAssetIsOverridable()
+    public function testGetCssAssetIsOverridable(): void
     {
         $overridedConverter = new OverridedConverter(['storage' => $this->storage]);
         $overridedConverter->overridedCssAssetResult = 'overrided/file.ext';
@@ -195,7 +194,7 @@ class ScssAssetConverterTest extends TestCase
         $this->assertTrue($this->storage->exists('base/path/overrided/file.ext'));
     }
 
-    public function testAlbertBorsosUseCase()
+    public function testAlbertBorsosUseCase(): void
     {
         // More info: https://github.com/LucidTaZ/yii2-scssphp/pull/12
         $this->storage->put('base/path/scss/style.scss', "#blop { color: black; }");


### PR DESCRIPTION
This allows using newer versions of dev tools and encourages users to upgrade away from 7.0, which is officially unsupported by now. It also adds testing for PHP 7.3.