### PR TITLE
Updated example code to use ScssPhp

### DIFF
--- a/README.md
+++ b/README.md
@@ -79,15 +79,13 @@ $config = [
     ],
     'container' => [
         'definitions' => [
-            'Leafo\ScssPhp\Compiler' => function () {
+            \ScssPhp\ScssPhp\Compiler::class => function () {
                 // You can also use a child class here:
-                $compiler = new Leafo\ScssPhp\Compiler();
-
-                // Customize the object, for example set a formatter:
-                $compiler->setFormatter('Leafo\ScssPhp\Formatter\Compressed');
+                $compiler = new \ScssPhp\ScssPhp\Compiler();
+                $compiler->setOutputStyle(\ScssPhp\ScssPhp\OutputStyle::COMPRESSED);
 
                 return $compiler;
-            },
+            }
         ],
     ],
 


### PR DESCRIPTION
The readme was not completely updated to reflect the change to ScssPhp.
This PR rectifies that and also provides a valid example on how to set a compressed output type.